### PR TITLE
Concurrency protection

### DIFF
--- a/attiny.go
+++ b/attiny.go
@@ -1,0 +1,86 @@
+/*
+attiny-controller - Communicates with ATtiny microcontroller
+Copyright (C) 2018, The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"time"
+
+	"golang.org/x/exp/io/i2c"
+)
+
+const (
+	attinyAddress = 0x04
+
+	// 3 was just a randomly chosen as the number for the attiny to return
+	// to indicate its presence.
+	magicReturn = 0x03
+
+	// Check for the ATtiny for up to a minute.
+	connectAttempts        = 20
+	connectAttemptInterval = 3 * time.Second
+
+	watchdogTimerAddress = 0x12
+	sleepAddress         = 0x11
+)
+
+// connectATtiny sets up a i2c device for talking to the ATtiny and
+// returns a wrapper for it. If no ATtiny was detected (nil, nil) will
+// be returned.
+func connectATtiny() (*attiny, error) {
+	dev, err := i2c.Open(&i2c.Devfs{Dev: "/dev/i2c-1"}, attinyAddress)
+	if err != nil {
+		return nil, err
+	}
+	if !detectATtiny(dev) {
+		dev.Close()
+		return nil, nil
+	}
+	return &attiny{dev: dev}, nil
+}
+
+func detectATtiny(dev *i2c.Device) bool {
+	for i := 0; i < connectAttempts; i++ {
+		time.Sleep(connectAttemptInterval)
+
+		buf := make([]byte, 1)
+		dev.Read(buf)
+		if buf[0] == magicReturn {
+			return true
+		}
+	}
+	return false
+}
+
+type attiny struct {
+	dev *i2c.Device
+}
+
+// PowerOff asks the ATtiny to turn the system off for the number of
+// minutes specified.
+func (a *attiny) PowerOff(minutes int) error {
+	lb := byte(minutes / 256)
+	rb := byte(minutes % 256)
+	return a.dev.Write([]byte{sleepAddress, lb, rb})
+}
+
+// PingWatchdog ping's the ATTiny's watchdog timer to prevent it from
+// rebooting the system.
+func (a *attiny) PingWatchdog() error {
+	return a.dev.Write([]byte{watchdogTimerAddress})
+}

--- a/attinyconfig.go
+++ b/attinyconfig.go
@@ -1,6 +1,20 @@
-// Copyright 2018 The Cacophony Project. All rights reserved.
-// Use of this source code is governed by the Apache License Version 2.0;
-// see the LICENSE file for further details.
+/*
+attiny-controller - Communicates with ATtiny microcontroller
+Copyright (C) 2018, The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -27,25 +27,11 @@ import (
 
 	"github.com/TheCacophonyProject/window"
 	arg "github.com/alexflint/go-arg"
-	i2c "golang.org/x/exp/io/i2c"
 )
 
-const (
-	// 3 was just a randomly chosen as the number for the attiny to return
-	// to indicate its presence.
-	magicReturn = 0x03
-
-	// Check for the ATtiny for up to a minute.
-	connectAttempts        = 20
-	connectAttemptInterval = 3 * time.Second
-
-	watchdogTimerAddress = 0x12
-	sleepAddress         = 0x11
-
-	// How long to wait before checking the recording window. This
-	// gives time to do something with the device before it turns off.
-	initialGracePeriod = 20 * time.Minute
-)
+// How long to wait before checking the recording window. This
+// gives time to do something with the device before it turns off.
+const initialGracePeriod = 20 * time.Minute
 
 var (
 	version = "<not set>"
@@ -105,19 +91,18 @@ func runMain() error {
 	args := procArgs()
 	log.Printf("running version: %s", version)
 
-	attiny, err := i2c.Open(&i2c.Devfs{Dev: "/dev/i2c-1"}, 0x04)
+	log.Println("connecting to attiny")
+	attiny, err := connectATtiny()
 	if err != nil {
 		return err
 	}
+	attinyPresent := attiny != nil
 
-	log.Println("connecting to attiny")
-	attinyPresent := connected(attiny)
-
-	log.Println("starting DBUS service")
+	log.Println("starting D-Bus service")
 	if err := startService(attinyPresent); err != nil {
 		return err
 	}
-	log.Println("started DBUS service")
+	log.Println("started D-Bus service")
 
 	if !attinyPresent {
 		log.Println("attiny not present")
@@ -153,11 +138,7 @@ func runMain() error {
 		log.Printf("minutes until active %d", minutesUntilActive)
 		if shouldTurnOff(minutesUntilActive) {
 			log.Println("shutting down...")
-			minutesUntilActive = minutesUntilActive - 2
-			lb := byte(minutesUntilActive / 256)
-			rb := byte(minutesUntilActive % 256)
-			err = attiny.Write([]byte{sleepAddress, lb, rb})
-			if err != nil {
+			if err := attiny.PowerOff(minutesUntilActive - 2); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -165,24 +146,10 @@ func runMain() error {
 	}
 }
 
-func connected(attiny *i2c.Device) bool {
-	for i := 0; i < connectAttempts; i++ {
-		time.Sleep(connectAttemptInterval)
-
-		buf := make([]byte, 1)
-		attiny.Read(buf)
-		if buf[0] == magicReturn {
-			return true
-		}
-	}
-	return false
-}
-
-func updateWatchdogTimer(attiny *i2c.Device) {
+func updateWatchdogTimer(a *attiny) {
 	log.Println("sending watchdog timer updates")
 	for {
-		err := attiny.Write([]byte{watchdogTimerAddress})
-		if err != nil {
+		if err := a.PingWatchdog(); err != nil {
 			log.Fatal(err)
 		}
 		time.Sleep(time.Minute)

--- a/main.go
+++ b/main.go
@@ -1,3 +1,21 @@
+/*
+attiny-controller - Communicates with ATtiny microcontroller
+Copyright (C) 2018, The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package main
 
 import (

--- a/service.go
+++ b/service.go
@@ -1,3 +1,21 @@
+/*
+attiny-controller - Communicates with ATtiny microcontroller
+Copyright (C) 2018, The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package main
 
 import (


### PR DESCRIPTION
The interface to the ATtiny has been extracted out to it's own type and concurrent access to the ATtiny is now prevented.

Also fixed up license headers.